### PR TITLE
fix: Trigger `MasonUpdateAllCompleted` after last notification message

### DIFF
--- a/lua/masonextracmds/mason/utils.lua
+++ b/lua/masonextracmds/mason/utils.lua
@@ -89,8 +89,8 @@ function M.notify_update_complete(updates_found)
     else
       utils.notify("No updates available")
     end
+    utils.trigger_event("User MasonUpdateAllCompleted")
   end, 1000) -- Ensure the callback is not executed ahead of time.
-  utils.trigger_event("User MasonUpdateAllCompleted")
 end
 
 return M


### PR DESCRIPTION
Currently, the notification message doesn't appear if you are doing a headless install like:

```
        nvim --headless \
          +verbose \
          +'Lazy! restore' \
          +'Lazy! clean' \
          +'Lazy! clear' \
          +'TSUpdateSync' \
          +'autocmd User MasonUpdateAllCompleted qall!' \
          +'MasonUpdateAll'
```